### PR TITLE
Use testify/require for testing

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -7,49 +7,35 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	pb "google.golang.org/protobuf/types/descriptorpb"
 )
 
-func requireNoError(t *testing.T, err error) {
+func requireProtoEqual(t *testing.T, want, got proto.Message) {
 	t.Helper()
-	if err != nil {
-		t.Fatalf("want: no error, got: %v", err)
-	}
-}
-
-func requireEqual(t *testing.T, want, got interface{}) {
-	t.Helper()
-	var opts []cmp.Option
-	var prefix string
-	_, wantOK := want.(proto.Message) //nolint:ifshort
-	_, gotOK := got.(proto.Message)   //nolint:ifshort
-	if wantOK && gotOK {
-		opts = append(opts, protocmp.Transform())
-		prefix = "protos "
-	}
-	if diff := cmp.Diff(want, got, opts...); diff != "" {
-		t.Errorf(prefix+"not equal (-want +got):\n%s", diff)
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("not equal (-want +got):\n%s", diff)
 	}
 }
 
 func TestFiledescriptorSet(t *testing.T) {
 	files, err := filepath.Glob("testdata/*.proto")
-	requireNoError(t, err)
+	require.NoError(t, err)
 	for _, file := range files {
 		t.Run(file, func(t *testing.T) {
 			fdName := strings.TrimPrefix(file, "testdata/")
 			importPaths := []string{"testdata"}
 			includeImports := true
 			got, err := NewFileDescriptorSet([]string{fdName}, importPaths, includeImports)
-			requireNoError(t, err)
+			require.NoError(t, err)
 
 			name := strings.TrimSuffix(filepath.Base(file), ".proto")
 			pbFile := "testdata/pb/" + name + ".pb"
 			want := loadPB(t, pbFile)
-			requireEqual(t, len(got.File), len(want.File))
-			requireEqual(t, want, got)
+			require.Equal(t, len(got.File), len(want.File))
+			requireProtoEqual(t, want, got)
 		})
 	}
 }
@@ -58,19 +44,19 @@ func TestNoIncludeImports(t *testing.T) {
 	importPaths := []string{"testdata"}
 	includeImports := false
 	got, err := NewFileDescriptorSet([]string{"06_proto3_import_transitive.proto"}, importPaths, includeImports)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	want := loadPB(t, "testdata/pb/06_proto3_import_transitive_no_include.pb")
-	requireEqual(t, len(got.File), len(want.File))
-	requireEqual(t, want, got)
+	require.Equal(t, len(got.File), len(want.File))
+	requireProtoEqual(t, want, got)
 }
 
 func loadPB(t *testing.T, file string) *pb.FileDescriptorSet {
 	t.Helper()
 	pbBytes, err := os.ReadFile(file)
-	requireNoError(t, err)
+	require.NoError(t, err)
 	fds := &pb.FileDescriptorSet{}
 	err = proto.Unmarshal(pbBytes, fds)
-	requireNoError(t, err)
+	require.NoError(t, err)
 	return fds
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,13 @@ go 1.17
 require (
 	github.com/alecthomas/participle/v2 v2.0.0-alpha7
 	github.com/google/go-cmp v0.5.6
+	github.com/stretchr/testify v1.4.0
 	google.golang.org/protobuf v1.27.1
 )
 
-require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/parser/conformance_test.go
+++ b/parser/conformance_test.go
@@ -4,23 +4,19 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestConformance(t *testing.T) {
 	files, err := filepath.Glob("../testdata/conformance/*.proto")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	for _, file := range files {
 		t.Run(file, func(t *testing.T) {
 			r, err := os.Open(file)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			_, err = Parse(file, r)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5,24 +5,18 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParser(t *testing.T) {
 	files, err := filepath.Glob("../testdata/*.proto")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	for _, file := range files {
 		t.Run(file, func(t *testing.T) {
 			r, err := os.Open(file)
-			if err != nil {
-				t.Error(err)
-			}
+			require.NoError(t, err)
 			_, err = Parse(file, r)
-			if err != nil {
-				t.Error(err)
-			}
+			require.NoError(t, err)
 		})
 	}
 }
@@ -44,13 +38,10 @@ func TestImports(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseString("test.proto", tt.source)
-			if err != nil {
-				t.Fatalf("got unexpected error: %v", err)
-			}
+			require.NoError(t, err)
+
 			result := imports(got)
-			if !cmp.Equal(result, tt.want) {
-				t.Errorf("ParseString()\n%s", cmp.Diff(result, tt.want))
-			}
+			require.Equal(t, tt.want, result)
 		})
 	}
 }

--- a/parser/unquote_test.go
+++ b/parser/unquote_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/participle/v2/lexer"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnquote(t *testing.T) {
@@ -18,11 +19,7 @@ func TestUnquote(t *testing.T) {
 	}
 	for _, test := range tests {
 		actual, err := unquote(lexer.Token{Value: test.input})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if actual.Value != test.expected {
-			t.Fatalf("%q (actual) != %q (expected)", actual.Value, test.expected)
-		}
+		require.NoError(t, err)
+		require.Equal(t, actual.Value, test.expected)
 	}
 }


### PR DESCRIPTION
Use testify/require for testing because we starting reinventing the
wheel with requireNoError and requireEqual. The aspiration of a
clean-room proto parser with only the participle dependency started
falling when we started using many google proto libraries to generated
FileDescirptors.