### PR TITLE
Rework Boolean in parser to capture false

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -76,11 +76,15 @@ type Value struct {
 
 	String    *string    `  @String+`
 	Number    *big.Float `| ("-" | "+")? (@Float | @Int)`
-	Bool      *bool      `| (@"true" | "false")`
+	Bool      *Boolean   `| @("true"|"false")`
 	Reference *string    `| @("."? Ident { "." Ident })`
 	ProtoText *ProtoText `| "{" @@ "}"`
 	Array     *Array     `| @@`
 }
+
+type Boolean bool
+
+func (b *Boolean) Capture(v []string) error { *b = v[0] == "true"; return nil }
 
 type ProtoText struct {
 	Pos lexer.Position

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -39,6 +39,8 @@ func TestParser(t *testing.T) {
 			  option (complex_opt2).(protobuf_unittest.garply).(corge).qux = 2121;
 			  option (.ComplexOptionType2.ComplexOptionType4.complex_opt4).waldo = 1971;
 			  option (strings) = "1" "2";
+			  option deprecated = true;
+			  option deprecated = false;
 			}
 			`,
 		expected: &Proto{
@@ -61,6 +63,14 @@ func TestParser(t *testing.T) {
 						{Option: &Option{
 							Name:  []*OptionName{{Name: "(strings)"}},
 							Value: &Value{String: strP("12")},
+						}},
+						{Option: &Option{
+							Name:  []*OptionName{{Name: "deprecated"}},
+							Value: &Value{Bool: boolP(true)},
+						}},
+						{Option: &Option{
+							Name:  []*OptionName{{Name: "deprecated"}},
+							Value: &Value{Bool: boolP(false)},
 						}},
 					},
 				}},
@@ -128,4 +138,9 @@ func toBig(n int) *big.Float {
 
 func strP(s string) *string {
 	return &s
+}
+
+func boolP(b bool) *Boolean {
+	bv := Boolean(b)
+	return &bv
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -37,7 +37,7 @@ func TestParser(t *testing.T) {
 			message VariousComplexOptions {
 			  option (complex_opt2).bar.(protobuf_unittest.corge).qux = 2008;
 			  option (complex_opt2).(protobuf_unittest.garply).(corge).qux = 2121;
-			  option .(.ComplexOptionType2.ComplexOptionType4.complex_opt4).waldo = 1971;
+			  option (.ComplexOptionType2.ComplexOptionType4.complex_opt4).waldo = 1971;
 			  option (strings) = "1" "2";
 			}
 			`,
@@ -55,7 +55,7 @@ func TestParser(t *testing.T) {
 							Value: &Value{Number: toBig(2121)},
 						}},
 						{Option: &Option{
-							Name:  []*OptionName{{Name: ".(.ComplexOptionType2.ComplexOptionType4.complex_opt4)"}, {Name: "waldo"}},
+							Name:  []*OptionName{{Name: "(.ComplexOptionType2.ComplexOptionType4.complex_opt4)"}, {Name: "waldo"}},
 							Value: &Value{Number: toBig(1971)},
 						}},
 						{Option: &Option{


### PR DESCRIPTION
Rework Boolean in parser to capture false used in Options.
Update parser_test.go for valid option input only.