### PR TITLE
Update integration tests to run options tests

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -37,7 +37,7 @@ type ast struct {
 	extends  []*parser.Extend
 }
 
-// NewFileDescriptorSet creates a FileDescriptorSet similar to protoc:
+// Compile creates a FileDescriptorSet similar to protoc:
 //
 // 		protoc -o filedescriptorset.pb -I importPath1 -I importPath2 --include_imports file1.proto file2.proto
 //
@@ -45,7 +45,7 @@ type ast struct {
 // of which a proto representation of the source proto files. The
 // FileDescriptorSet is the intermediary representation typically
 // passed to proto plugins.
-func NewFileDescriptorSet(files, importPaths []string, includeImports bool) (*pb.FileDescriptorSet, error) {
+func Compile(files, importPaths []string, includeImports bool) (*pb.FileDescriptorSet, error) {
 	all, filtered, err := compileFileDescriptorSets(files, importPaths, includeImports)
 	if err != nil {
 		return nil, err

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -45,7 +45,7 @@ func TestFiledescriptorSet(t *testing.T) {
 				includeImports = false
 			}
 
-			fds, err := NewFileDescriptorSet([]string{fdName}, importPaths, includeImports)
+			fds, err := Compile([]string{fdName}, importPaths, includeImports)
 			require.NoError(t, err)
 			// Deterministic forces maps to be ordered by keys which comes
 			// to bear for option value `{s1: "1"  s2: "2"};`

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -25,12 +25,10 @@ func requireProtoEqual(t *testing.T, want, got proto.Message) {
 
 func TestFiledescriptorSet(t *testing.T) {
 	files, err := filepath.Glob("testdata/*.proto")
-	// skip test 17 and 18 as we don't interpret custom options yet.
+	tmpDir := t.TempDir()
+	// skip test 17 as we don't interpret custom options yet that are scalars.
 	skip := map[string]bool{
-		"testdata/17_proto2_custom_options.proto":           true,
-		"testdata/18_a_proto2_aggregate_opt.proto":          true,
-		"testdata/18_b_proto2_aggregate_opt.proto":          true,
-		"testdata/18_proto2_aggregate_opt_no_include.proto": true,
+		"testdata/17_proto2_custom_options.proto": true,
 	}
 	require.NoError(t, err)
 	for _, file := range files {
@@ -47,11 +45,19 @@ func TestFiledescriptorSet(t *testing.T) {
 				includeImports = false
 			}
 
-			got, err := NewFileDescriptorSet([]string{fdName}, importPaths, includeImports)
+			fds, err := NewFileDescriptorSet([]string{fdName}, importPaths, includeImports)
 			require.NoError(t, err)
+			// Deterministic forces maps to be ordered by keys which comes
+			// to bear for option value `{s1: "1"  s2: "2"};`
+			m := proto.MarshalOptions{Deterministic: true}
+			b, err := m.Marshal(fds)
+			require.NoError(t, err)
+			gotFile := filepath.Join(tmpDir, name+".pb")
+			require.NoError(t, os.WriteFile(gotFile, b, 0600))
 
-			pbFile := "testdata/pb/" + name + ".pb"
-			want := loadPB(t, pbFile)
+			wantFile := "testdata/pb/" + name + ".pb"
+			want := loadPB(t, wantFile)
+			got := loadPB(t, gotFile)
 			require.Equal(t, len(got.File), len(want.File))
 			requireProtoEqual(t, want, got)
 		})
@@ -87,87 +93,4 @@ func TestUninterpretedOptions(t *testing.T) {
 	require.True(t, uOpts[0].Name[0].GetIsExtension())
 	require.Equal(t, "s1", uOpts[0].Name[1].GetNamePart())
 	require.False(t, uOpts[0].Name[1].GetIsExtension())
-}
-
-func TestUninterpretedAggregateOptions(t *testing.T) {
-	fdName := "18_proto2_aggregate_opt_no_include.proto"
-	importPaths := []string{"testdata"}
-	_, fds, err := compileFileDescriptorSets([]string{fdName}, importPaths, false)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(fds.File))
-	require.Equal(t, 2, len(fds.File[0].MessageType))
-	require.Equal(t, 1, len(fds.File[0].MessageType[1].Options.UninterpretedOption))
-
-	uOpt := fds.File[0].MessageType[1].Options.UninterpretedOption[0]
-	// option (opt1) = {s1: "1" s2: "2" };
-	require.Equal(t, 1, len(uOpt.Name))
-	require.Equal(t, ".pkg.opt1", uOpt.Name[0].GetNamePart())
-	require.True(t, uOpt.Name[0].GetIsExtension())
-	want := `
-  s1: "1"
-  s2: "2"
-`
-	require.Equal(t, want, uOpt.GetAggregateValue())
-}
-
-/*
-This test is flaky - sometimes it passes, sometimes it doesn't
-I believe this indicates that there is a bug in protoc when custom
-options are defined and used in the same file.
-
-func TestAggregateOptionsSameFile(t *testing.T) {
-	// When a custom option is defined and used in the same file
-	// it get marshalled in the FileDescriptor as Unknown field,
-	// rather than as Extension.
-	//
-	// Resulting error:
-	// -(want) "50001":      protoreflect.RawFields{0x8a, 0xb5, 0x18, 0x06, 0x0a, 0x01, 0x31, 0x12, 0x01, 0x32},
-	// +( got) "[pkg.opt1]": s`{s1:"1"  s2:"2"}`,
-	//
-	// Writing the compiled FileDescriptorSet to File and reading it in again
-	// gives the same result, which seems to indicate that the results are correct
-	// and wire compatible
-	name := "18_proto2_aggregate_opt_no_include"
-	fdName := name + ".proto"
-	importPaths := []string{"testdata"}
-	fds, err := NewFileDescriptorSet([]string{fdName}, importPaths, false)
-	require.NoError(t, err)
-
-	dir := t.TempDir()
-	fname := filepath.Join(dir, name+".pb")
-	f, err := os.Create(fname)
-	require.NoError(t, err)
-	b, err := proto.Marshal(fds)
-	require.NoError(t, err)
-	f.Write(b)
-	require.NoError(t, f.Close())
-
-	pbFile := "testdata/pb/" + name + ".pb"
-	want := loadPB(t, pbFile)
-	got := loadPB(t, fname)
-	requireProtoEqual(t, want, got)
-}
-*/
-
-func TestAggregateOptionsSeparateFiles(t *testing.T) {
-	// This test contains the same protos as TestAggregateOptionsSameFile
-	// only split over two files:
-	// one containing the extension definition (a)
-	// the second containing the extension usage (b)
-	name := "18_b_proto2_aggregate_opt"
-	fdName := name + ".proto"
-	importPaths := []string{"testdata"}
-	fds, err := NewFileDescriptorSet([]string{fdName}, importPaths, true)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(fds.File))
-	got := fds.File[2]
-	require.Equal(t, fdName, got.GetName())
-
-	pbFile := "testdata/pb/" + name + ".pb"
-	wantFDS := loadPB(t, pbFile)
-	require.Equal(t, 3, len(wantFDS.File))
-	want := fds.File[2]
-	require.Equal(t, fdName, got.GetName())
-
-	requireProtoEqual(t, want, got)
 }


### PR DESCRIPTION
Update integration tests to run options tests. We need to write the
compiler output to disk first and read it back in for identical results,
otherwise Extensions are interpreted for the in-memory FileDescriptorSet
but not interpreted for the FileDesciprtorSet read from disk.

    - "50001":      protoreflect.RawFields{0x8a, 0xb5, 0x18, 0x06, 0x0a, 0x01, 0x31, 0x12, 0x01, 0x32},
    + "[pkg.opt1]": s`{s1:"1", s2:"2"}`,

Rename NewFileDescriptorSet to Compile