### PR TITLE
parser: Handle trailing comments in prototext options

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -91,6 +91,8 @@ type ProtoText struct {
 	Pos lexer.Position
 
 	Fields []*ProtoTextField `( @@ ( "," | ";" )? )*`
+
+	TrailingComments *Comments `@@?`
 }
 
 type ProtoTextField struct {

--- a/testdata/comments.proto
+++ b/testdata/comments.proto
@@ -7,3 +7,13 @@ syntax = "proto2";
 message Test {
   repeated string s = 1;
 }
+
+option (foo) = {
+  // Comment before field
+  f1: "foo"
+  /* multi-line
+   * comment
+   */
+  f2: "bar"
+  // trailing comment
+}


### PR DESCRIPTION
Parse trailing comments after the last field in a prototext option. This
is useful for commenting out the last field of a prototext option, which
is a time-honoured debugging tradition. It must be supported.