### PR TITLE
Close imported files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all:  build test lint  ## build, test and lint go source
 ci: clean check-uptodate all  ## Full clean build and up-to-date checks as run on CI
 
 check-uptodate: sync pb tidy
-	test -z "$$(git status --porcelain)"
+	test -z "$$(git status --porcelain -- go.mod go.sum '*.proto' '*.pb')"
 
 .PHONY: all check-uptodate ci clean
 


### PR DESCRIPTION
Close imported files, this error only showed up with a too many open files
error on big parallel tests.

Make `make ci` less picky and only fail when generated files are dirty.